### PR TITLE
Update README.md: remove Future Features and Limitations sections, add Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,21 +220,6 @@ The action will:
 - Exit with code 1 for API errors or terminal conversation states (`FAILED`, `ERROR`, `CANCELLED`)
 - Exit with code 0 for successful completion
 
-## Limitations
-
-- Maximum polling timeout: configurable (default 20 minutes)
-- Requires valid OpenHands API key
-- Conversation status polling may have slight delays
-- File prompts must be accessible in the workflow workspace
-
-## Future Features
-
-Planned enhancements include:
-- Automatic PR/issue commenting with results
-- Trajectory output saving as artifacts
-- Enhanced error reporting and retry logic
-- Integration with GitHub Apps for better permissions
-
 ## Contributing
 
 This action is maintained by All Hands AI. For issues, feature requests, or contributions, please visit the [repository](https://github.com/All-Hands-AI/openhands-github-action).
@@ -247,4 +232,5 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 - 📖 [OpenHands Documentation](https://docs.all-hands.dev)
 - 💬 [Community Discord](https://discord.gg/ESHStjSjD4)
+- 💬 [Join our Slack](https://dub.sh/openhands)
 - 🐛 [Report Issues](https://github.com/All-Hands-AI/openhands-github-action/issues)


### PR DESCRIPTION
This PR updates the README.md file with the following changes:

## Changes Made

- ✅ **Removed Future Features section** - Cleaned up planned enhancements that are no longer needed in the documentation
- ✅ **Removed Limitations section** - Removed the limitations section as requested
- ✅ **Added Slack link** - Added a link to the OpenHands Slack community (https://dub.sh/openhands) in the Support section

## Summary

The README.md is now more streamlined without the Future Features and Limitations sections, and users can now easily find the Slack community link alongside other support resources.

The Slack link has been added to the Support section with the emoji 💬 to maintain consistency with the existing Discord link.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5bf829b7829d42e98932bf11263f33cb)